### PR TITLE
Update create-image.sh to point to tails 0.20 release.

### DIFF
--- a/create-image.sh
+++ b/create-image.sh
@@ -40,8 +40,8 @@ mount_iso () {
 }
 
 download_tails () {
-  curl -o data/tails.iso.sig https://tails.boum.org/torrents/files/tails-i386-0.19.iso.sig
-  curl -o data/tails.iso http://dl.amnesia.boum.org/tails/stable/tails-i386-0.19/tails-i386-0.19.iso
+  curl -o data/tails.iso.sig https://tails.boum.org/torrents/files/tails-i386-0.20.iso.sig
+  curl -o data/tails.iso http://dl.amnesia.boum.org/tails/stable/tails-i386-0.20/tails-i386-0.20.iso
   gpg --verify data/tails.sig
 }
 


### PR DESCRIPTION
The 0.19 release links have been removed now that 0.20 is out. This pull request points the curl commands to the new file releases.
