### PR TITLE
Fixed gpg verify command

### DIFF
--- a/create-image.sh
+++ b/create-image.sh
@@ -40,9 +40,11 @@ mount_iso () {
 }
 
 download_tails () {
+  curl -o data/tails-signing.key https://tails.boum.org/tails-signing.key
+  gpg --keyid-format long --import data/tails-signing.key
   curl -o data/tails.iso.sig https://tails.boum.org/torrents/files/tails-i386-0.20.iso.sig
   curl -o data/tails.iso http://dl.amnesia.boum.org/tails/stable/tails-i386-0.20/tails-i386-0.20.iso
-  gpg --verify data/tails.sig
+  gpg --verify data/tails.iso.sig
 }
 
 list_disks () {


### PR DESCRIPTION
First the verify was failing because it was pointing to tails.sig (curl is outputting to tails.iso.sig). It then failed due to not having the public signing key, so I added a curl to download that and the gpg import. Do you think there may be trust issues with including that step as part of this script?
