### PR TITLE
Fix stale links to Tails files, version 0.20.1 in create-image.sh

### DIFF
--- a/create-image.sh
+++ b/create-image.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -x
 
-TAILS_ISO_URL="http://dl.amnesia.boum.org/tails/stable/tails-i386-0.20/tails-i386-0.20.iso"
-TAILS_SIG_URL="https://tails.boum.org/torrents/files/tails-i386-0.20.iso.sig"
+TAILS_ISO_URL="http://dl.amnesia.boum.org/tails/stable/tails-i386-0.20.1/tails-i386-0.20.1.iso"
+TAILS_SIG_URL="https://tails.boum.org/torrents/files/tails-i386-0.20.1.iso.sig"
 TAILS_KEY_URL="https://tails.boum.org/tails-signing.key"
 
 if [ ! -d "data" ]; then


### PR DESCRIPTION
File:   create-image.sh

Update create-image.sh to point to tails 0.20.1 release.

The Tails .iso and consequently, it's GPG signature file, have been
_updated_ to version 0.20.1. **This patch simply updates the URL's to point
to the correct locations at the Tails repositories.**

Without this patch create-image.sh is broken as of September 28, 2013.
With these changes things work as expected.
(Tails developers have moved the links for deprecated version 0.20 elsewhere.)

I appreciate all the work done by hellais and the other contributors to make this repo for those of us who like to experiment with Tails on OS X. I'd like to learn more about the persistence function, and how to make that available on an OS X USB drive. Please keep me in the loop regarding development in that area!

**_Keep up the great work!**_
