### PR TITLE
Tested on MacBook Pro, Late 2011 (hangs on boot)

### DIFF
--- a/tested-on.md
+++ b/tested-on.md
@@ -38,7 +38,7 @@ Notes:
 
 * **trackpad** no
 
-Notes:
+Notes: Hangs just after `Waiting for /dev to be fully populated...`.
 
 ## MacBook Pro, Early 2011 (MacBookPro8,2)
 


### PR DESCRIPTION
Used an already downloaded and verified copy of `tails-i386-0.22.1.iso` (and consequently skipped [`verify_tails`](https://github.com/hellais/TAILS-OSX/blob/5e9d2986c15136b70388b20e8da5f66348416645/create-image.sh#L120), cf. #23).
Hung here:
![tails_hang](https://f.cloud.github.com/assets/1165411/2153915/14051052-942e-11e3-817e-b87e661117c1.JPG)
