### PR TITLE
Download iso to a tmp location, move to tails.iso once complete

### DIFF
--- a/create-image.sh
+++ b/create-image.sh
@@ -84,7 +84,8 @@ verify_tails () {
 }
 
 download_tails () {
-  curl -k -o data/tails.iso $TAILS_ISO_URL
+  curl -k -o data/tails-tmp.iso $TAILS_ISO_URL
+  mv data/tails-tmp.iso data/tails.iso
 }
 
 list_disks () {


### PR DESCRIPTION
If the network connection drops before the download of the Tails iso is complete, the script will fail to re-download the file and the signature verification will fail. I suggest that the file is downloaded to a temporary location and moved to data/tails.iso once the download is complete.
