### PR TITLE
Changed links to Tails v1.2 ISO and signature

### DIFF
--- a/create-image.sh
+++ b/create-image.sh
@@ -14,8 +14,8 @@ if [ "$1" == "clean" ]; then
 fi
 
 set -x
-TAILS_ISO_URL="http://dl.amnesia.boum.org/tails/stable/tails-i386-1.1.2/tails-i386-1.1.2.iso"
-TAILS_SIG_URL="https://tails.boum.org/torrents/files/tails-i386-1.1.2.iso.sig"
+TAILS_ISO_URL="http://dl.amnesia.boum.org/tails/stable/tails-i386-1.2/tails-i386-1.2.iso"
+TAILS_SIG_URL="https://tails.boum.org/torrents/files/tails-i386-1.2.iso.sig"
 TAILS_KEY_URL="https://tails.boum.org/tails-signing.key"
 
 if [ ! -d "data" ]; then


### PR DESCRIPTION
1.1.2 was no longer available for download, which prompted the error message "ERROR! The iso does not seem to be signed by the TAILS key. Something is fishy!" to be displayed.

Changed links to get v1.2 and the script now works
